### PR TITLE
fix: updated vignettes to include correct order of install

### DIFF
--- a/vignettes/package_vignette.Rmd
+++ b/vignettes/package_vignette.Rmd
@@ -29,14 +29,15 @@ First, let's install necessary packages. You may skip this step if you have
 installed the packages before.
 
 ```{r, warning=FALSE, message=FALSE, eval=FALSE}
-# install iimi
-install.packages(c("iimi", "dplyr"))
-
 # install Biostrings
 if (!require("BiocManager", quietly = TRUE))
     install.packages("BiocManager")
 
+BiocManager::install(c("GenomicAlignments", "Rsamtools"))
 BiocManager::install("Biostrings")
+
+# install iimi
+install.packages(c("iimi", "dplyr"))
 ```
 
 ### 1.2. Loading packages


### PR DESCRIPTION
Since CRAN does not allow a package to preform it's own dependancy installation from non CRAN registries, the user must read the vignette and correctly install all external dependancies that are not available to the default CRAN registry.

### Changes

- Updated vignettes to ensure correct order of installation takes place

fixes: #17 